### PR TITLE
3.0.0 - Removed client-level caching, and added middleware class

### DIFF
--- a/bandiera-client.gemspec
+++ b/bandiera-client.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
 
   spec.add_dependency 'rest-client'
-  spec.add_dependency 'moneta'
   spec.add_dependency 'macmillan-utils'
 end

--- a/bandiera-client.gemspec
+++ b/bandiera-client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'pry'
 

--- a/lib/bandiera/client.rb
+++ b/lib/bandiera/client.rb
@@ -3,12 +3,27 @@ require 'json'
 require 'logger'
 
 module Bandiera
+  ##
+  # Client class for communicating with a Bandiera server.
+  #
+  # @since 1.0.0
+  # @attr [Float] timeout The HTTP timeout value (seconds) for requests
+  # @attr [String] client_name The client name passed along with HTTP requests
+  # @attr_reader [Logger] logger The logger object in use
+  #
   class Client
     autoload :VERSION, 'bandiera/client/version'
 
     attr_accessor :timeout, :client_name
     attr_reader :logger
 
+    ##
+    # Builds a new instance of Bandiera::Client
+    #
+    # @param [String] base_uri The URI of the Bandiera server
+    # @param [Logger] logger A logger object
+    # @param [String] client_name A client name to pass through along with the HTTP requests
+    #
     def initialize(base_uri = 'http://localhost', logger = Logger.new($stdout), client_name = nil)
       @base_uri       = base_uri
       @base_uri       << '/api' unless @base_uri.match(/\/api$/)
@@ -17,11 +32,23 @@ module Bandiera
       @client_name    = client_name
     end
 
+    # @deprecated This functionality was deprecated/removed in 3.0.0
     def cache_strategy=(_)
       warn 'The caching features in Bandiera::Client have been removed as of v3.0.0, please consider using using ' \
            'the Bandiera::Middleware class shipped as part of the "bandiera-client" gem.'
     end
 
+    ##
+    # Get the active/inactive state for a single feature flag
+    #
+    # @param [String] group The group of feature flags we're interested in
+    # @param [String] feature The feature flag we want to retrieve
+    # @param [Hash] params Additional parameters to pass through to the Bandiera request
+    # @option params [String] :user_id A unique user identifier, or UUID (for use with percentage based feature flags)
+    # @option params [String] :user_group A group to assign the identify the user with (for use with group based feature flags)
+    #
+    # @return [Boolean] True/False - depending on if the feature is on or off
+    #
     def get_feature(group, feature, params = {}, http_opts = {})
       path             = "/v2/groups/#{group}/features/#{feature}"
       default_response = false
@@ -34,6 +61,16 @@ module Bandiera
 
     alias_method :enabled?, :get_feature
 
+    ##
+    # Get the active/inactive state for all feature flags in a group
+    #
+    # @param [String] group The group of feature flags we're interested in
+    # @param [Hash] params Additional parameters to pass through to the Bandiera request
+    # @option params [String] :user_id A unique user identifier, or UUID (for use with percentage based feature flags)
+    # @option params [String] :user_group A group to assign the identify the user with (for use with group based feature flags)
+    #
+    # @return [Hash] A hash of feature flag pairs. Keys are the feature flag names, values are the active/inactive states.
+    #
     def get_features_for_group(group, params = {}, http_opts = {})
       path             = "/v2/groups/#{group}/features"
       default_response = {}
@@ -44,6 +81,14 @@ module Bandiera
       get_and_handle_exceptions(path, params, http_opts, default_response, error_msg_prefix)
     end
 
+    ##
+    # Get the active/inactive state for all feature flags known on the Bandiera server
+    #
+    # @param [Hash] params Additional parameters to pass through to the Bandiera request
+    # @option params [String] :user_id A unique user identifier, or UUID (for use with percentage based feature flags)
+    # @option params [String] :user_group A group to assign the identify the user with (for use with group based feature flags)
+    #
+    # @return [Hash] A hash of hashes containing the feature flag active/inactive states grouped by 'group'
     def get_all(params = {}, http_opts = {})
       path             = '/v2/all'
       default_response = {}

--- a/lib/bandiera/client/version.rb
+++ b/lib/bandiera/client/version.rb
@@ -1,5 +1,5 @@
 module Bandiera
   class Client
-    VERSION = '2.2.2'
+    VERSION = '3.0.0'
   end
 end

--- a/lib/bandiera/middleware.rb
+++ b/lib/bandiera/middleware.rb
@@ -1,20 +1,42 @@
 require 'macmillan/utils'
 
 module Bandiera
+  ##
+  # Rack middleware for talking to a Bandiera feature flagging service.
+  #
+  # The benefit of using this middleware is two-fold when working with a Bandiera server:
+  #
+  # 1. Performance - Using this middleware, you will only call the Bandiera server once per-request (in contrast to using the `enabled?` method where you will make one request per-use).
+  # 2. Better Quality Code - If you use the more advanced features in Bandiera (user groups and percentages) you will no longer need to pass around user objects and UUIDs in your code.  This does assume the use of other middlewares to supply user objects and UUIDs though.
+  #
+  # This middleware can be used in conjunction with the {Macmillan::Utils::Middleware::Uuid} (or one of your own design) to automatically generate UUIDs for your users. See http://cruft.io for more information on this approach.
+  #
+  # @since 3.0.0
+  #
   class Middleware
-    def initialize(app,
-                   client:,
-                   groups:            [],
-                   uuid_env_key:      Macmillan::Utils::Middleware::Uuid.env_key,
-                   user_env_key:      'user.user',
-                   user_env_key:      'current_user',
-                   user_group_method: :email)
+    ##
+    # Builds a new instance of Bandiera::Middleware
+    #
+    # @param app The rack application
+    # @param [Hash] opts Additional options for the middleware
+    # @option opts [Bandiera::Client] :client The Bandiera::Client class to use
+    # @option opts [Array] :groups ([]) The feature flag groups to request and store in the rack env
+    # @option opts [String] :uuid_env_key (Macmillan::Utils::Middleware::Uuid.env_key) The rack env key containing a UUID for your current user (to pass to `user_id` in Bandiera)
+    # @option opts [String] :user_env_key ('current_user') The rack env key containing your currently logged in user
+    # @option opts [Symbol] :user_group_method (:email) The method to call on the current user to pass to `user_group` in Bandiera
+    #
+    # @see Bandiera::Client
+    # @see Macmillan::Utils::Middleware::Uuid
+    #
+    def initialize(app, opts = {})
       @app               = app
-      @client            = client
-      @groups            = groups
-      @uuid_env_key      = uuid_env_key
-      @user_env_key      = user_env_key
-      @user_group_method = user_group_method
+      @client            = opts[:client]
+      @groups            = opts[:groups] || []
+      @uuid_env_key      = opts[:uuid_env_key] || Macmillan::Utils::Middleware::Uuid.env_key
+      @user_env_key      = opts[:user_env_key] || 'current_user'
+      @user_group_method = opts[:user_group_method] || :email
+
+      fail ArgumentError, 'You must supply a Bandiera::Client' unless @client
     end
 
     def call(env)

--- a/lib/bandiera/middleware.rb
+++ b/lib/bandiera/middleware.rb
@@ -1,0 +1,44 @@
+require 'macmillan/utils'
+
+module Bandiera
+  class Middleware
+    def initialize(app,
+                   client:,
+                   groups:            [],
+                   uuid_env_key:      Macmillan::Utils::Middleware::Uuid.env_key,
+                   user_env_key:      'user.user',
+                   user_env_key:      'current_user',
+                   user_group_method: :email)
+      @app               = app
+      @client            = client
+      @groups            = groups
+      @uuid_env_key      = uuid_env_key
+      @user_env_key      = user_env_key
+      @user_group_method = user_group_method
+    end
+
+    def call(env)
+      dup.process(env)
+    end
+
+    def process(env)
+      request = Rack::Request.new(env)
+
+      user       = request.env[@user_env_key]
+      user_group = user ? user.public_send(@user_group_method) : nil
+      uuid       = request.env[@uuid_env_key]
+
+      if @groups.empty?
+        @client.get_all(user_group: user_group, user_id: uuid).each do |group, flags|
+          request.env["bandiera.#{group}"] = flags
+        end
+      else
+        @groups.each do |group|
+          request.env["bandiera.#{group}"] = @client.get_features_for_group(group, user_group: user_group, user_id: uuid)
+        end
+      end
+
+      @app.call(request.env)
+    end
+  end
+end

--- a/spec/lib/bandiera/client_spec.rb
+++ b/spec/lib/bandiera/client_spec.rb
@@ -9,10 +9,10 @@ describe Bandiera::Client do
   context 'when a client name is provided' do
     let(:group)   { 'pubserv' }
     let(:feature) { 'log-stats' }
-    let(:url)     { "#{api_uri}/v2/groups/#{group}/features" }
+    let(:url)     { "#{api_uri}/v2/groups/#{group}/features/#{feature}" }
 
     it 'sends it as part of the headers' do
-      stub = stub_api_request(url, { 'response' => {} }, { 'Bandiera-Client' => 'asdf' })
+      stub   = stub_api_request(url, { 'response' => {} }, { 'Bandiera-Client' => 'asdf' })
       client = Bandiera::Client.new(api_uri, logger, 'asdf')
       client.enabled?(group, feature)
       expect(stub).to have_been_requested
@@ -36,83 +36,6 @@ describe Bandiera::Client do
     end
   end
 
-  describe '#enabled?' do
-    context 'with cache strategy :single_feature' do
-      before do
-        subject.cache_strategy = :single_feature
-      end
-
-      context 'and an empty cache' do
-        it 'calls #get_feature' do
-          expect(subject).to receive(:get_feature).once
-          subject.enabled?('foo', 'bar')
-        end
-      end
-
-      context 'and a primed cache' do
-        before do
-          cache_key = subject.send(:build_cache_key, 'foo', 'bar', {})
-          subject.cache.store(cache_key, false)
-        end
-
-        it 'does not call #get_feature' do
-          expect(subject).to_not receive(:get_feature)
-          subject.enabled?('foo', 'bar')
-        end
-      end
-    end
-
-    context 'with cache strategy :group' do
-      before do
-        subject.cache_strategy = :group
-      end
-
-      context 'and an empty cache' do
-        it 'calls #get_features_for_group' do
-          expect(subject).to receive(:get_features_for_group).once
-          subject.enabled?('foo', 'bar')
-        end
-      end
-
-      context 'and a primed cache' do
-        before do
-          cache_key = subject.send(:build_cache_key, 'foo', 'bar', {})
-          subject.cache.store(cache_key, false)
-        end
-
-        it 'does not call #get_features_for_group' do
-          expect(subject).to_not receive(:get_features_for_group)
-          subject.enabled?('foo', 'bar')
-        end
-      end
-    end
-
-    context 'with cache strategy :all' do
-      before do
-        subject.cache_strategy = :all
-      end
-
-      context 'and an empty cache' do
-        it 'calls #get_all' do
-          expect(subject).to receive(:get_all).once
-          subject.enabled?('foo', 'bar')
-        end
-      end
-
-      context 'and a primed cache' do
-        before do
-          cache_key = subject.send(:build_cache_key, 'foo', 'bar', {})
-          subject.cache.store(cache_key, false)
-        end
-
-        it 'does not call #get_all' do
-          expect(subject).to_not receive(:get_all)
-          subject.enabled?('foo', 'bar')
-        end
-      end
-    end
-  end
-
   describe '#get_feature' do
     let(:group)   { 'pubserv' }
     let(:feature) { 'log-stats' }
@@ -125,14 +48,6 @@ describe Bandiera::Client do
 
         expect(response).to be true
         expect(stub).to have_been_requested
-      end
-
-      it 'stores the feature value in the cache' do
-        stub_api_request(url, 'response' => true)
-        cache_key = subject.send(:build_cache_key, group, feature, {})
-
-        subject.get_feature(group, feature)
-        expect(subject.cache.key?(cache_key)).to be true
       end
 
       context 'and the user has passed through some extra params' do
@@ -174,14 +89,6 @@ describe Bandiera::Client do
 
         expect(response).to be false
       end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_return(status: [0, ''])
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_feature(group, feature)
-      end
     end
 
     context 'bandiera is having some problems' do
@@ -194,14 +101,6 @@ describe Bandiera::Client do
 
         expect(response).to be false
       end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_return(status: 500, body: '')
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_feature(group, feature)
-      end
     end
 
     context 'bandiera times out' do
@@ -213,14 +112,6 @@ describe Bandiera::Client do
         response = subject.get_feature(group, feature)
 
         expect(response).to be false
-      end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_timeout
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_feature(group, feature)
       end
     end
   end
@@ -237,19 +128,6 @@ describe Bandiera::Client do
 
         expect(response).to eq(feature_hash)
         expect(stub).to have_been_requested
-      end
-
-      it 'stores the feature values in the cache' do
-        feature_hash = { 'show-stuff' => true, 'show-other-stuff' => false }
-        stub_api_request(url, 'response' => feature_hash)
-
-        subject.get_features_for_group(group)
-
-        cache_key = subject.send(:build_cache_key, group, 'show-stuff', {})
-        expect(subject.cache.key?(cache_key)).to be true
-
-        cache_key = subject.send(:build_cache_key, group, 'show-other-stuff', {})
-        expect(subject.cache.key?(cache_key)).to be true
       end
 
       context 'and the user has passed through some extra params' do
@@ -291,14 +169,6 @@ describe Bandiera::Client do
 
         expect(response).to be {}
       end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_return(status: [0, ''])
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_features_for_group(group)
-      end
     end
 
     context 'bandiera is having some problems' do
@@ -311,14 +181,6 @@ describe Bandiera::Client do
 
         expect(response).to be {}
       end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_return(status: 500, body: '')
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_features_for_group(group)
-      end
     end
 
     context 'bandiera times out' do
@@ -330,14 +192,6 @@ describe Bandiera::Client do
         response = subject.get_features_for_group(group)
 
         expect(response).to be {}
-      end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_timeout
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_features_for_group(group)
       end
     end
   end
@@ -353,19 +207,6 @@ describe Bandiera::Client do
 
         expect(response).to eq(feature_hash)
         expect(stub).to have_been_requested
-      end
-
-      it 'stores the feature values in the cache' do
-        feature_hash = { 'pubserv' => { 'show-stuff' => true, 'show-other-stuff' => false } }
-        stub_api_request(url, 'response' => feature_hash)
-
-        subject.get_all
-
-        cache_key = subject.send(:build_cache_key, 'pubserv', 'show-stuff', {})
-        expect(subject.cache.key?(cache_key)).to be true
-
-        cache_key = subject.send(:build_cache_key, 'pubserv', 'show-other-stuff', {})
-        expect(subject.cache.key?(cache_key)).to be true
       end
 
       context 'and the user has passed through some extra params' do
@@ -407,14 +248,6 @@ describe Bandiera::Client do
 
         expect(response).to be {}
       end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_return(status: [0, ''])
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_all
-      end
     end
 
     context 'bandiera is having some problems' do
@@ -427,14 +260,6 @@ describe Bandiera::Client do
 
         expect(response).to be {}
       end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_return(status: 500, body: '')
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_all
-      end
     end
 
     context 'bandiera times out' do
@@ -446,14 +271,6 @@ describe Bandiera::Client do
         response = subject.get_all
 
         expect(response).to be {}
-      end
-
-      it 'does not store anything in the cache' do
-        stub_request(:get, url).to_timeout
-
-        expect(subject.cache).to_not receive(:store)
-
-        subject.get_all
       end
     end
   end

--- a/spec/lib/bandiera/middleware_spec.rb
+++ b/spec/lib/bandiera/middleware_spec.rb
@@ -1,0 +1,184 @@
+require 'spec_helper'
+require 'macmillan/utils/rspec/rack_test_helper'
+
+describe Bandiera::Middleware do
+  let(:app)             { ->(env) { [200, env, 'app'] } }
+  let(:request)         { req_for('http://example.com') }
+  let(:bandiera_client) { double(:bandiera_client) }
+  let(:bandiera_groups) { [] }
+  let(:user)            { double(:user, email: 'bob.flemming@cough.com') }
+  let(:user_uuid)       { '12345-12345-12345' }
+
+  subject { described_class.new(app, client: bandiera_client, groups: bandiera_groups) }
+
+  context 'when a bandiera client has NOT been passed' do
+    it 'raises an error' do
+      expect { described_class.new(app) }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'feature flag "groups"' do
+    context 'when NO feature flag "groups" have been defined' do
+      it 'calls #get_all on the bandiera_client' do
+        expect(bandiera_client).to receive(:get_all).and_return({})
+
+        subject.call(request.env)
+      end
+
+      it 'stores the returned flags in the env' do
+        pubserv_flags     = { 'show-stuff' => true }
+        search_flags      = { 'show-search' => false }
+        bandiera_response = { 'pubserv' => pubserv_flags, 'search' => search_flags }
+
+        expect(bandiera_client).to receive(:get_all).and_return(bandiera_response)
+
+        _status, headers, _body = subject.call(request.env)
+
+        expect(headers['bandiera.pubserv']).to eq(pubserv_flags)
+        expect(headers['bandiera.search']).to eq(search_flags)
+      end
+    end
+
+    context 'when SOME feature flag "groups" have been defined' do
+      let(:bandiera_groups) { ['search'] }
+
+      it 'calls #get_features_for_group on the bandiera_client' do
+        expect(bandiera_client).to receive(:get_features_for_group).and_return([])
+
+        subject.call(request.env)
+      end
+
+      it 'stores the returned flags in the env' do
+        bandiera_response = { 'show-search' => false }
+
+        expect(bandiera_client).to receive(:get_features_for_group).and_return(bandiera_response)
+
+        _status, headers, _body = subject.call(request.env)
+
+        expect(headers['bandiera.search']).to eq(bandiera_response)
+      end
+    end
+  end
+
+  context '"uuid_env_key"' do
+    before do
+      request.env[Macmillan::Utils::Middleware::Uuid.env_key] = user_uuid
+    end
+
+    context 'HAS NOT been set' do
+      it 'uses the default key from Macmillan::Utils' do
+        expect(bandiera_client).to receive(:get_all).with(hash_including(user_id: user_uuid)).and_return({})
+
+        subject.call(request.env)
+      end
+
+      context "and the nothing has set the #{Macmillan::Utils::Middleware::Uuid.env_key} value" do
+        it 'passes nil to the #user_id param' do
+          request.env.delete(Macmillan::Utils::Middleware::Uuid.env_key)
+
+          expect(bandiera_client).to receive(:get_all).with(hash_including(user_id: nil)).and_return({})
+
+          subject.call(request.env)
+        end
+      end
+    end
+
+    context 'HAS been set' do
+      let(:uuid_env_key) { 'wibble' }
+      let(:uuid)         { 'qwerty' }
+
+      subject { described_class.new(app, client: bandiera_client, groups: bandiera_groups, uuid_env_key: uuid_env_key) }
+
+      it 'uses the key passed into it' do
+        request.env[uuid_env_key] = uuid
+
+        expect(bandiera_client).to receive(:get_all).with(hash_including(user_id: uuid)).and_return({})
+
+        subject.call(request.env)
+      end
+    end
+  end
+
+  context '"user_env_key"' do
+    before do
+      request.env['current_user'] = user
+    end
+
+    context 'when there is no current user' do
+      it 'does not cause errors' do
+        expect do
+          request.env['current_user'] = nil
+
+          expect(bandiera_client).to receive(:get_all).with(hash_including(user_group: nil)).and_return({})
+
+          subject.call(request.env)
+        end.to_not raise_error
+      end
+    end
+
+    context 'HAS NOT been set' do
+      it 'uses the default key - "current_user"' do
+        expect(bandiera_client).to receive(:get_all).with(hash_including(user_group: user.email)).and_return({})
+
+        subject.call(request.env)
+      end
+    end
+
+    context 'HAS been set' do
+      let(:user_env_key) { 'wibble' }
+      let(:user)         { double(:user, email: 'robert.paulson@example.com') }
+
+      subject { described_class.new(app, client: bandiera_client, groups: bandiera_groups, user_env_key: user_env_key) }
+
+      it 'uses the key passed to it' do
+        request.env[user_env_key] = user
+
+        expect(bandiera_client).to receive(:get_all).with(hash_including(user_group: user.email)).and_return({})
+
+        subject.call(request.env)
+      end
+    end
+  end
+
+  context '"user_group_method"' do
+    before do
+      request.env['current_user'] = user
+    end
+
+    context 'when there is no current user' do
+      it 'does not cause errors' do
+        expect do
+          request.env['current_user'] = nil
+
+          expect(bandiera_client).to receive(:get_all).with(hash_including(user_group: nil)).and_return({})
+
+          subject.call(request.env)
+        end.to_not raise_error
+      end
+    end
+
+    context 'HAS NOT been set' do
+      it 'uses the default method - "email"' do
+        email = 'ron.manager@football.com'
+
+        expect(user).to receive(:public_send).with(:email).once.and_return(email)
+        expect(bandiera_client).to receive(:get_all).with(hash_including(user_group: email)).and_return({})
+
+        subject.call(request.env)
+      end
+    end
+
+    context 'HAS been set' do
+      subject { described_class.new(app, client: bandiera_client, groups: bandiera_groups, user_group_method: :role) }
+
+      it 'uses the method passed to it' do
+        role = 'Administrator'
+
+        expect(user).to receive(:public_send).with(:role).once.and_return(role)
+        expect(bandiera_client).to receive(:get_all).with(hash_including(user_group: role)).and_return({})
+
+        subject.call(request.env)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,4 @@ require 'macmillan/utils/test_helpers/simplecov_helper'
 require 'pry'
 
 require 'bandiera/client'
+require 'bandiera/middleware'


### PR DESCRIPTION
The client level caching code should never have happened really - it complicated the codebase and wasn't the way we were using it at Nature...

In this PR i've ported our Bandiera middleware code into the client gem so other people can use it in the same way (if they choose to).